### PR TITLE
Issue 16

### DIFF
--- a/app/src/main/java/com/example/dineDelight/utils/BlobUtils.kt
+++ b/app/src/main/java/com/example/dineDelight/utils/BlobUtils.kt
@@ -8,6 +8,8 @@ import android.provider.MediaStore
 import java.io.ByteArrayOutputStream
 import android.util.Base64
 import java.util.UUID
+import java.io.File
+import java.io.FileOutputStream
 
 object BlobUtils {
     fun Uri.toBlob(context: Context): ByteArray? {
@@ -39,11 +41,11 @@ object BlobUtils {
         return BitmapFactory.decodeByteArray(this, 0, this.size)
     }
 
-    fun Bitmap.toUri(context: Context): Uri? {
+    fun Bitmap.toStoredUri(context: Context): Uri? {
         return try {
             val bytes = ByteArrayOutputStream()
             this.compress(Bitmap.CompressFormat.PNG, 100, bytes)
-            val uniqueFileName = "Title-${UUID.randomUUID()}.jpg"
+            val uniqueFileName = "stored-image-${UUID.randomUUID()}.png"
             val path = MediaStore.Images.Media.insertImage(context.contentResolver, this, uniqueFileName, null)
             Uri.parse(path)
         } catch (e: Exception) {
@@ -63,5 +65,27 @@ object BlobUtils {
      */
     fun ByteArray.toBase64String(): String {
         return Base64.encodeToString(this, Base64.DEFAULT)
+    }
+
+    fun Uri.toBitmap(context: Context): Bitmap? {
+        return try {
+            val inputStream = context.contentResolver.openInputStream(this)
+            BitmapFactory.decodeStream(inputStream)
+        } catch (e: Exception) {
+            null
+        }
+    }
+
+    fun Bitmap.toUri(context: Context): Uri? {
+        return try {
+            val file = File(context.cacheDir, "temp-image-${UUID.randomUUID()}.png")
+            val outputStream = FileOutputStream(file)
+            this.compress(Bitmap.CompressFormat.PNG, 100, outputStream)
+            outputStream.flush()
+            outputStream.close()
+            Uri.fromFile(file)
+        } catch (e: Exception) {
+            null
+        }
     }
 } 

--- a/app/src/main/java/com/example/dineDelight/utils/BlobUtils.kt
+++ b/app/src/main/java/com/example/dineDelight/utils/BlobUtils.kt
@@ -7,6 +7,7 @@ import android.net.Uri
 import android.provider.MediaStore
 import java.io.ByteArrayOutputStream
 import android.util.Base64
+import java.util.UUID
 
 object BlobUtils {
     fun Uri.toBlob(context: Context): ByteArray? {
@@ -42,10 +43,10 @@ object BlobUtils {
         return try {
             val bytes = ByteArrayOutputStream()
             this.compress(Bitmap.CompressFormat.PNG, 100, bytes)
-            val path = MediaStore.Images.Media.insertImage(context.contentResolver, this, "Title", null)
+            val uniqueFileName = "Title-${UUID.randomUUID()}.jpg"
+            val path = MediaStore.Images.Media.insertImage(context.contentResolver, this, uniqueFileName, null)
             Uri.parse(path)
-        }
-        catch (e: Exception) {
+        } catch (e: Exception) {
             null
         }
     }


### PR DESCRIPTION
Fixes #16 

### Changes

Loading the images on the RAM instead of saving them locally on the device.

### Enhancement TODO (https://github.com/Lina0Elman/DineDelight/issues/20)

When we scroll the images down and up again, we can see that they are loaded again and not saved.
We should add them to the ROOM cache database, load them once, and retrieve them from there if they already exist.
