### PR TITLE
Fix Email Text Dissapear When Pressing The Logout Button

### DIFF
--- a/app/src/main/java/com/example/dineDelight/pages/ProfileScreen.kt
+++ b/app/src/main/java/com/example/dineDelight/pages/ProfileScreen.kt
@@ -34,7 +34,7 @@ fun ProfileScreen(navController: NavController) {
     val user = firebaseAuth.currentUser
     val userId = user?.uid.orEmpty()
     var userName by rememberSaveable { mutableStateOf(user?.displayName.orEmpty()) }
-    val userEmail = user?.email.orEmpty()
+    val userEmail by rememberSaveable { mutableStateOf(user?.email.orEmpty()) }
 
     var profileImageUri by rememberSaveable { mutableStateOf<Uri?>(null) }
     var isLoading by rememberSaveable { mutableStateOf(false) }


### PR DESCRIPTION
Small bug fix.

In the Profile page, when pressing the "logout" button, the email value disappears for a moment.
Fixed this by using a `rememberSaveable` to save the email value.

### The bug:

![email](https://github.com/user-attachments/assets/96f38cb4-be90-429e-85fc-e25f2fc98d9f)

### The fix:

![emailfix](https://github.com/user-attachments/assets/f68ade2d-090f-4d29-94b0-7a7970ae97bc)
