### PR TITLE
Feat shrink image size

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,11 @@
 # DineDelight
 
-## Requirements
+## Download & Install The App
+
+https://github.com/Lina0Elman/DineDelight/releases
+
+## Development
+
+### Requirements
 
 [Setup Firebase connection](docs/SetupFirebaseConnection.md)

--- a/app/src/main/java/com/example/dineDelight/pages/ProfileScreen.kt
+++ b/app/src/main/java/com/example/dineDelight/pages/ProfileScreen.kt
@@ -71,14 +71,10 @@ fun ProfileScreen(navController: NavController) {
                     val blob = selectedUri.toBlob(context)
                     val base64String = blob?.toBase64String()
                     if (!base64String.isNullOrEmpty()) {
-                        if (base64String.length > 1048487) {
-                            throw IllegalArgumentException("Image size exceeds the limit.")
-                        }
-                        val newImage = Image(
+                        ImageRepository.addImage(Image(
                             id = userId,
                             blobBase64String = base64String
-                        )
-                        ImageRepository.addImage(newImage)
+                        ))
 
                         val updates = userProfileChangeRequest {
                             photoUri = selectedUri

--- a/app/src/main/java/com/example/dineDelight/pages/RestaurantReviewsScreen.kt
+++ b/app/src/main/java/com/example/dineDelight/pages/RestaurantReviewsScreen.kt
@@ -30,7 +30,6 @@ import com.example.dineDelight.utils.BlobUtils.toBlob
 import com.example.dineDelight.utils.BlobUtils.toBitmap
 import com.example.dineDelight.utils.BlobUtils.toUri
 import com.google.firebase.auth.FirebaseAuth
-import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
@@ -180,13 +179,10 @@ fun RestaurantReviewsScreen(navController: NavController, restaurant: Restaurant
                                     val imageId = UUID.randomUUID().toString()
                                     withContext(Dispatchers.IO) {
                                         selectedImageUri?.let { uri ->
-                                            val blob = uri.toBlob(context)!!.toBase64String()
-                                            if (blob.length > 1048487) {
-                                                throw IllegalArgumentException("Image size exceeds the limit.")
-                                            }
+                                            val blobBase64String = uri.toBlob(context)!!.toBase64String()
                                             ImageRepository.addImage(Image(
                                                 id = imageId,
-                                                blobBase64String = blob
+                                                blobBase64String = blobBase64String
                                             ))
                                         }
                                     }

--- a/app/src/main/java/com/example/dineDelight/pages/UpdateReviewScreen.kt
+++ b/app/src/main/java/com/example/dineDelight/pages/UpdateReviewScreen.kt
@@ -66,13 +66,8 @@ fun UpdateReviewScreen(navController: NavController, reviewId: String) {
         contract = ActivityResultContracts.GetContent(),
         onResult = { uri: Uri? ->
             uri?.let { selectedUri ->
-                val blob = selectedUri.toBlob(context)?.toBase64String() ?: ""
-                if (blob.length > 1048487) {
-                    errorMessage = "Image size exceeds the limit."
-                } else {
-                    updatedImageUri = selectedUri
-                    errorMessage = null
-                }
+                updatedImageUri = selectedUri
+                errorMessage = null
             }
         }
     )
@@ -157,13 +152,12 @@ fun UpdateReviewScreen(navController: NavController, reviewId: String) {
                                     var newImageId = oldReview.imageId
                                     if (updatedImageUri != originalImageUri && updatedImageUri != null) {
                                         val blob = updatedImageUri?.toBlob(context)
-                                        val base64String = blob?.toBase64String()
-                                        if (!base64String.isNullOrEmpty()) {
-                                            val newImage = Image(
+                                        val blobBase64String = blob?.toBase64String()
+                                        if (!blobBase64String.isNullOrEmpty()) {
+                                            val newImage = ImageRepository.addImage(Image(
                                                 id = oldReview.imageId ?: UUID.randomUUID().toString(),
-                                                blobBase64String = base64String
-                                            )
-                                            ImageRepository.addImage(newImage)
+                                                blobBase64String = blobBase64String
+                                            ))
                                             newImageId = newImage.id
                                         }
                                     }

--- a/app/src/main/java/com/example/dineDelight/repositories/ImageRepository.kt
+++ b/app/src/main/java/com/example/dineDelight/repositories/ImageRepository.kt
@@ -11,6 +11,11 @@ import com.google.firebase.firestore.FirebaseFirestore
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.tasks.await
+import android.graphics.Bitmap
+import android.graphics.BitmapFactory
+import com.example.dineDelight.utils.BlobUtils.toBase64String
+import com.example.dineDelight.utils.BlobUtils.toBlob
+import java.io.ByteArrayOutputStream
 
 object ImageRepository {
     private lateinit var imageDao: ImageDao
@@ -32,14 +37,18 @@ object ImageRepository {
         imageDao = db.imageDao()
     }
 
-    suspend fun addImage(image: Image) {
+    suspend fun addImage(image: Image): Image {
         try {
-            val imageEntity = image.toImageEntity()
+            // Compress the image before adding
+            val compressedImage = compressImage(image)
+            val imageEntity = compressedImage.toImageEntity()
             imageDao.insertImage(imageEntity)
             // Add image to Firestore
-            imagesCollection.document(image.id).set(image).await()
+            imagesCollection.document(compressedImage.id).set(compressedImage).await()
             // Update local state flow after adding
-            _images.value += image
+            _images.value += compressedImage
+
+            return compressedImage
         } catch (e: Exception) {
             // Handle any errors
             throw e
@@ -98,5 +107,45 @@ object ImageRepository {
             // Handle any errors
             throw e
         }
+    }
+
+    private fun compressImage(image: Image): Image {
+        val maxSize = 1048487 // 1 MB in bytes
+        var compressedImage = image // Start with the original image
+
+        // Check the size of the image and compress if necessary
+        while (getImageSize(compressedImage) > maxSize) {
+            // Reduce the quality of the image
+            compressedImage = reduceImageQuality(compressedImage)
+        }
+
+        return compressedImage // Return the compressed image
+    }
+
+    private fun getImageSize(image: Image): Int {
+        // Convert the image to a byte array and return its size
+        val byteArrayOutputStream = ByteArrayOutputStream()
+        val blob = image.blobBase64String!!.toBlob()
+        val bitmap = BitmapFactory.decodeByteArray(blob, 0, blob!!.size)
+        bitmap.compress(Bitmap.CompressFormat.JPEG, 100, byteArrayOutputStream) // Compress to JPEG format
+        return byteArrayOutputStream.size() // Return the size in bytes
+    }
+
+    private fun reduceImageQuality(image: Image): Image {
+        val byteArrayOutputStream = ByteArrayOutputStream()
+        val blob = image.blobBase64String!!.toBlob()
+        val bitmap = BitmapFactory.decodeByteArray(blob, 0, blob!!.size)
+
+        // Start with a quality of 100 and reduce until the size is acceptable
+        var quality = 100
+        do {
+            byteArrayOutputStream.reset() // Clear the output stream
+            bitmap.compress(Bitmap.CompressFormat.JPEG, quality, byteArrayOutputStream)
+            quality -= 10 // Reduce quality by 10 each iteration
+        } while (getImageSize(image) > 1048487 && quality > 0)
+
+        // Create a new Image object from the compressed byte array
+        val compressedImageBytes = byteArrayOutputStream.toByteArray()
+        return Image(id = image.id, blobBase64String = compressedImageBytes.toBase64String())
     }
 }

--- a/app/src/main/java/com/example/dineDelight/repositories/ImageRepository.kt
+++ b/app/src/main/java/com/example/dineDelight/repositories/ImageRepository.kt
@@ -111,7 +111,8 @@ object ImageRepository {
 
     private fun compressImage(image: Image): Image {
         val maxSize = 1048487 // 1 MB in bytes
-        var compressedImage = image // Start with the original image
+        val resizedImage = resizeImage(image, 700) // Resize the image first
+        var compressedImage = resizedImage // Start with the resized image
 
         // Check the size of the image and compress if necessary
         while (getImageSize(compressedImage) > maxSize) {
@@ -120,6 +121,28 @@ object ImageRepository {
         }
 
         return compressedImage // Return the compressed image
+    }
+
+    private fun resizeImage(image: Image, maxDimension: Int): Image {
+        val blob = image.blobBase64String!!.toBlob()
+        val originalBitmap = BitmapFactory.decodeByteArray(blob, 0, blob!!.size)
+        val width = originalBitmap.width
+        val height = originalBitmap.height
+
+        // Calculate the scaling factor
+        val scaleFactor = Math.min(maxDimension.toFloat() / width, maxDimension.toFloat() / height)
+
+        // Create a new bitmap with the new dimensions
+        val newWidth = (width * scaleFactor).toInt()
+        val newHeight = (height * scaleFactor).toInt()
+        val resizedBitmap = Bitmap.createScaledBitmap(originalBitmap, newWidth, newHeight, true)
+
+        // Convert the resized bitmap back to a byte array
+        val byteArrayOutputStream = ByteArrayOutputStream()
+        resizedBitmap.compress(Bitmap.CompressFormat.JPEG, 100, byteArrayOutputStream)
+        val resizedImageBytes = byteArrayOutputStream.toByteArray()
+
+        return Image(id = image.id, blobBase64String = resizedImageBytes.toBase64String())
     }
 
     private fun getImageSize(image: Image): Int {


### PR DESCRIPTION
This helps to enhance the loading speed of the images, but unfortunately, it does not solve the problem completely.

The speed of the image loadings should be similar to the speed of the "meals" API images, which is quite fast, and usable.

### Updated the insertion of images

- Removed all image size restrictions - All images sizes are now acceptable.
- Before saving an image:
  1. Resize it to 700px
  2. If its size is still larger than 1MB, compress it over and over again until its size is under 1MB.
  3. Insert the image to the databases ROOM and Firestore.

